### PR TITLE
fix: CV download hyperlink

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                 expertise in design, installation, testing and maintenance of
                 software systems.....
               </p>
-              <a href="images/Dennis.pdf" class="btn hire-me" download>Download CV</a>
+              <a href="images/Dennis.pdf" target="_blank" class="btn hire-me" download>Download CV</a>
             </div>
             <div class="home-img padd-15">
               <img src="images/me.jpg" alt="Me Image" />


### PR DESCRIPTION
- The hyperlink for the CV download was not working correctly.
- This commit fixes the hyperlink to ensure it points to the correct location and opens in a new tab.

issue: #20